### PR TITLE
Update cmd.to_format to support more commands & Remove redundant meta

### DIFF
--- a/src/smt2/builder.lean
+++ b/src/smt2/builder.lean
@@ -14,7 +14,7 @@ format.join $ list.intersperse "\n" $ (list.map to_fmt $ (build []).snd).reverse
 meta def smt2.builder.run {α : Type} (build : smt2.builder α) : (except string α × list smt2.cmd) :=
 build []
 
-meta def smt2.builder.fail {α : Type} : string → smt2.builder α :=
+def smt2.builder.fail {α : Type} : string → smt2.builder α :=
 fun msg s, (except.error msg, s)
 
 meta instance (α : Type) : has_to_format (smt2.builder α) :=

--- a/src/smt2/syntax.lean
+++ b/src/smt2/syntax.lean
@@ -119,6 +119,7 @@ meta def cmd.to_format : cmd → format
 | (declare_fun sym ps rs) := "(declare-fun " ++ sym ++
     format.bracket " (" ")" (format.join $ list.intersperse " " $ list.map to_fmt ps) ++ " " ++ to_fmt rs ++ ")"
 | (declare_sort sym arity) := "(declare-sort " ++ sym ++ " " ++ to_string arity ++ ")"
+| (reset) := "(reset)"
 | _ := "NYI"
 
 meta instance : has_to_format cmd :=


### PR DESCRIPTION
Hello. I'm new to smt2_interface repository, and I'd like to submit a small patch. :)

There are two small changes:

- Update `cmd.to_format` so it correctly returns "(reset)" when `reset` command is given.
- Remove `meta` tag from `smt2.builder.fail` function because it is not needed.

I'd like to get comments from this patch. Thank you!